### PR TITLE
feat: add now argument to githubAppJwt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,12 @@ import { Options, Result } from "./types";
 export async function githubAppJwt({
   id,
   privateKey,
-  timeDifference = 0,
-}: Options): Promise<Result> {
   // When creating a JSON Web Token, it sets the "issued at time" (iat) to 30s
   // in the past as we have seen people running situations where the GitHub API
   // claimed the iat would be in future. It turned out the clocks on the
   // different machine were not in sync.
-  const now = Math.floor(Date.now() / 1000) - 30 + timeDifference;
+  now = Math.floor(Date.now() / 1000) - 30,
+}: Options): Promise<Result> {
   const expiration = now + 60 * 10; // JWT expiration time (10 minute maximum)
 
   const payload = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,14 @@ import { Options, Result } from "./types";
 
 export async function githubAppJwt({
   id,
-  privateKey
+  privateKey,
+  timeDifference = 0,
 }: Options): Promise<Result> {
   // When creating a JSON Web Token, it sets the "issued at time" (iat) to 30s
   // in the past as we have seen people running situations where the GitHub API
   // claimed the iat would be in future. It turned out the clocks on the
   // different machine were not in sync.
-  const now = Math.floor(Date.now() / 1000) - 30;
+  const now = Math.floor(Date.now() / 1000) - 30 + timeDifference;
   const expiration = now + 60 * 10; // JWT expiration time (10 minute maximum)
 
   const payload = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,16 +5,17 @@ import { Options, Result } from "./types";
 export async function githubAppJwt({
   id,
   privateKey,
+  now = Math.floor(Date.now() / 1000),
+}: Options): Promise<Result> {
   // When creating a JSON Web Token, it sets the "issued at time" (iat) to 30s
   // in the past as we have seen people running situations where the GitHub API
   // claimed the iat would be in future. It turned out the clocks on the
   // different machine were not in sync.
-  now = Math.floor(Date.now() / 1000) - 30,
-}: Options): Promise<Result> {
-  const expiration = now + 60 * 10; // JWT expiration time (10 minute maximum)
+  const nowWithSafetyMargin = now - 30
+  const expiration = nowWithSafetyMargin + 60 * 10; // JWT expiration time (10 minute maximum)
 
   const payload = {
-    iat: now, // Issued at time
+    iat: nowWithSafetyMargin, // Issued at time
     exp: expiration,
     iss: id
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type Token = string;
 export type Options = {
   id: AppId;
   privateKey: PrivateKey;
-  crypto?: Crypto;
+  timeDifference?: number;
 };
 
 export type Result = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type Token = string;
 export type Options = {
   id: AppId;
   privateKey: PrivateKey;
-  timeDifference?: number;
+  now?: number;
 };
 
 export type Result = {

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -105,10 +105,10 @@ test("Include the time difference in the expiration and issued_at field", async 
 
   expect(result).toEqual(expect.objectContaining({
     appId: APP_ID,
-    expiration: 610
+    expiration: 580
   }))
 
   const resultPayload = JSON.parse(atob(result.token.split('.')[1]))
-  expect(resultPayload.exp).toEqual(610)
-  expect(resultPayload.iat).toEqual(10)
+  expect(resultPayload.exp).toEqual(580)
+  expect(resultPayload.iat).toEqual(-20)
 })

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -95,3 +95,20 @@ test("README example for app auth with private key in PKCS#8 format", async () =
     token: BEARER
   });
 });
+
+test("Include the time difference in the expiration and issued_at field", async () => {
+  const result = await githubAppJwt({
+    id: APP_ID,
+    privateKey: PRIVATE_KEY_PKCS8,
+    timeDifference: 10
+  })
+
+  expect(result).toEqual(expect.objectContaining({
+    appId: APP_ID,
+    expiration: 580
+  }))
+
+  const resultPayload = JSON.parse(atob(result.token.split('.')[1]))
+  expect(resultPayload.exp).toEqual(580)
+  expect(resultPayload.iat).toEqual(-20)
+})

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -100,15 +100,15 @@ test("Include the time difference in the expiration and issued_at field", async 
   const result = await githubAppJwt({
     id: APP_ID,
     privateKey: PRIVATE_KEY_PKCS8,
-    timeDifference: 10
+    now: 10
   })
 
   expect(result).toEqual(expect.objectContaining({
     appId: APP_ID,
-    expiration: 580
+    expiration: 610
   }))
 
   const resultPayload = JSON.parse(atob(result.token.split('.')[1]))
-  expect(resultPayload.exp).toEqual(580)
-  expect(resultPayload.iat).toEqual(-20)
+  expect(resultPayload.exp).toEqual(610)
+  expect(resultPayload.iat).toEqual(10)
 })


### PR DESCRIPTION
Hey @gr2m 👋 

This adds a `now` optional argument to `githubAppJwt` which the user of this library can use to specify the current "now" time. It will default to `Math.floor(Date.now() / 1000) - 30` to keep the current functionality when a user doesn't specify a `now` value. This also changes the `iat` to be set to the value of `now` passed in and calculates `exp` to the value of `now` plus 600 seconds (10 minutes).

This is used for cases where the GitHub API time is sufficiently
different from the system time. https://github.com/octokit/auth-app.js/issues/146