### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    target-branch: "v1.x"
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    target-branch: "main"
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
## what

- Enable dependabot

## why

- Automatic dependency updates for `v1.x` and `main` branches

## references

- Closes #79 
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch