### PR TITLE
build(renovate): backport config to `1.x` branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,5 +99,10 @@
         }
       ]
     ]
+  },
+  "renovate": {
+    "extends": [
+      "github>gr2m/.github"
+    ]
   }
 }


### PR DESCRIPTION
## what
- Enable renovatebot on v1 branch

## why
- Keep v1 up to date until more users migrate to v2

## references
- Previous PR #81 
- Relates to issue #79 