### PR TITLE
fix: typo error in `Node.js` usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,12 @@ If you use Node.js, you can convert the format before passing it to `universal-g
 import crypto from "node:crypto";
 import githubAppJwt from "universal-github-app-jwt";
 
-const privateKeyPkcs8 = crypto.createPrivateKey(process.env.PRIVATE_KEY).export({
-  type: "pkcs8",
-  format: "pem",
-});
+const privateKeyPkcs8 = crypto
+  .createPrivateKey(process.env.PRIVATE_KEY)
+  .export({
+    type: "pkcs8",
+    format: "pem",
+  });
 
 const { token, appId, expiration } = await githubAppJwt({
   id: process.env.APP_ID,

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ import githubAppJwt from "universal-github-app-jwt";
 const privateKeyPkcs8 = crypto.createPrivateKey(process.env.PRIVATE_KEY).export({
   type: "pkcs8",
   format: "pem",
-}
+});
 
 const { token, appId, expiration } = await githubAppJwt({
   id: process.env.APP_ID,


### PR DESCRIPTION
This Pull Request fixes the typo error in the `Node.js` usage example [section](https://github.com/gr2m/universal-github-app-jwt#converting-pkcs1-to-pkcs8) of the documentation/ReadMe.

### Change Made

- Added closing parenthesis to the example code 

```js
const privateKeyPkcs8 = crypto.createPrivateKey(process.env.PRIVATE_KEY).export({
  type: "pkcs8",
  format: "pem",
});
```

😉 