### PR TITLE
fix: replace escaped newlines with actual newlines in privateKey values

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For a complete implementation of GitHub App authentication strategies, see [`@oc
         <code>string</code>
       </th>
       <td>
-        <strong>Required</strong>. Content of the <code>*.pem</code> file you downloaded from the app’s about page. You can generate a new private key if needed. Make sure to preserve the line breaks.
+        <strong>Required</strong>. Content of the <code>*.pem</code> file you downloaded from the app’s about page. You can generate a new private key if needed. Make sure to preserve the line breaks. If your private key contains escaped newlines (`\\n`), they will be automatically replaced with actual newlines.
       </td>
     </tr>
     <tr>

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ export default async function githubAppJwt({
   privateKey,
   now = Math.floor(Date.now() / 1000),
 }) {
+  // Private keys are often times configured as environment variables, in which case line breaks are escaped using `\\n`.
+  // Replace these here for convenience.
+  const privateKeyWithNewlines = privateKey.replace(/\\n/g, '\n');
+
   // When creating a JSON Web Token, it sets the "issued at time" (iat) to 30s
   // in the past as we have seen people running situations where the GitHub API
   // claimed the iat would be in future. It turned out the clocks on the
@@ -26,7 +30,7 @@ export default async function githubAppJwt({
   };
 
   const token = await getToken({
-    privateKey,
+    privateKey: privateKeyWithNewlines,
     payload,
   });
 

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -162,3 +162,18 @@ test("Include the time difference in the expiration and issued_at field", async 
   t.is(resultPayload.exp, 580);
   t.is(resultPayload.iat, -20);
 });
+
+test("Replace escaped line breaks with actual linebreaks", async (t) => {
+  MockDate.set(0);
+
+  const result = await githubAppJwt({
+    id: APP_ID,
+    privateKey: PRIVATE_KEY_PKCS8.replace(/\n/g, "\\n"),
+  });
+
+  t.deepEqual(result, {
+    appId: APP_ID,
+    expiration: 570,
+    token: BEARER,
+  });
+});


### PR DESCRIPTION
Implements automatic newline conversion for private keys and updates documentation accordingly.

- **Code Update**: Modifies `index.js` to automatically replace escaped newlines (`\\n`) in the `privateKey` argument with actual newline characters before passing it to the `getToken()` function. This ensures compatibility with private keys defined in environment variables or other sources where newlines are escaped.
- **Documentation Update**: Enhances the `README.md` file by adding a note under the `options.privateKey` section. It now informs users that escaped newlines in the private key will be automatically replaced with actual newline characters, accommodating private keys stored with escaped newlines.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gr2m/universal-github-app-jwt?shareId=eeba4cd6-11d3-4ce6-b0f8-ef65c84d6d61).