### PR TITLE
feat: `options.id` can be set to Client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ For a complete implementation of GitHub App authentication strategies, see [`@oc
         <code>options.id</code>
       </th>
       <th>
-        <code>number</code>
+        <code>number | string</code>
       </th>
       <td>
-        <strong>Required</strong>. Find <strong>App ID</strong> on the app’s about page in settings.
+        <strong>Required</strong>. The GitHub App's ID or Client ID. For <code>github.com</code> and GHES 3.14+, it is recommended to use the Client ID.
       </td>
     </tr>
     <tr>
@@ -154,7 +154,7 @@ For a complete implementation of GitHub App authentication strategies, see [`@oc
         <code>number</code>
       </th>
       <td>
-        The GitHub App database ID passed in <code>options.id</code>.
+        The GitHub App database ID or Client ID passed in <code>options.id</code>.
       </td>
     </tr>
     <tr>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 export type Options = {
-  id: number;
+  id: number | string;
   privateKey: string;
   now?: number;
 };
 
 export type Result = {
-  appId: number;
+  appId: number | string;
   expiration: number;
   token: string;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
-export type Options = {
-  id: number | string;
+export type Options<IdType extends number | string = number> = {
+  id: IdType;
   privateKey: string;
   now?: number;
 };
 
-export type Result = {
-  appId: number | string;
+export type Result<IdType extends number | string = number> = {
+  appId: IdType extends string ? string : number;
   expiration: number;
   token: string;
 };
 
-export default function githubAppJwt(options: Options): Promise<Result>;
+export default function githubAppJwt<T extends number | string = number>(options: Options<T>): Promise<Result<T>>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,7 +7,7 @@ export async function test() {
     privateKey: "",
   });
 
-  expectType<number>(result.appId);
+  expectType<number | string>(result.appId);
   expectType<number>(result.expiration);
   expectType<string>(result.token);
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -11,3 +11,15 @@ export async function test() {
   expectType<number>(result.expiration);
   expectType<string>(result.token);
 }
+
+// Test case to verify `id` can be set to a string
+export async function testWithStringId() {
+  const resultWithStringId = await githubAppJwt({
+    id: "client_id_string",
+    privateKey: "",
+  });
+
+  expectType<number>(resultWithStringId.appId);
+  expectType<number>(resultWithStringId.expiration);
+  expectType<string>(resultWithStringId.token);
+}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,7 +7,7 @@ export async function test() {
     privateKey: "",
   });
 
-  expectType<number | string>(result.appId);
+  expectType<number>(result.appId);
   expectType<number>(result.expiration);
   expectType<string>(result.token);
 }
@@ -19,7 +19,7 @@ export async function testWithStringId() {
     privateKey: "",
   });
 
-  expectType<number | string>(resultWithStringId.appId);
+  expectType<string>(resultWithStringId.appId);
   expectType<number>(resultWithStringId.expiration);
   expectType<string>(resultWithStringId.token);
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,7 +19,7 @@ export async function testWithStringId() {
     privateKey: "",
   });
 
-  expectType<number>(resultWithStringId.appId);
+  expectType<number | string>(resultWithStringId.appId);
   expectType<number>(resultWithStringId.expiration);
   expectType<string>(resultWithStringId.token);
 }

--- a/internals.d.ts
+++ b/internals.d.ts
@@ -1,7 +1,7 @@
 export type Payload = {
   iat: number;
   exp: number;
-  iss: number;
+  iss: number | string;
 };
 
 export type Header = { alg: "RS256"; typ: "JWT" };

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -177,3 +177,16 @@ test("Replace escaped line breaks with actual linebreaks", async (t) => {
     token: BEARER,
   });
 });
+
+// New test for id set to Client ID
+test("id set to Client ID", async (t) => {
+  MockDate.set(0);
+
+  const result = await githubAppJwt({
+    id: "client_id_string",
+    privateKey: PRIVATE_KEY_PKCS8,
+  });
+
+  t.is(typeof result.token, "string");
+  t.is(result.appId, "client_id_string");
+});


### PR DESCRIPTION
This pull request updates the handling and documentation of the `id` argument to accept both a number (App ID) or a string (Client ID), enhancing flexibility in accordance with GitHub's recommendations.

- **Updates type definitions**: Modifies `index.d.ts` and `internals.d.ts` to allow the `id` parameter and `appId` result to be either a number or a string.
- **Revises documentation**: Adjusts `README.md` to clarify that `options.id` can be set to either the App ID or Client ID, and recommends using the Client ID for `github.com` and GHES 3.14+. The resulting `appId` can also be a string accordingly.
- **Expands test coverage**: Adds a new test case in `index.test-d.ts` and `test/node.test.js` to verify functionality when `id` is set to a string.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gr2m/universal-github-app-jwt?shareId=55133e84-6bb6-47e0-90f4-46f46d487700).