### PR TITLE
Replace ArrayBuffer with Uint8Array for edge-runtime compatibility

### DIFF
--- a/lib/get-token.js
+++ b/lib/get-token.js
@@ -5,8 +5,8 @@ import {
   isOpenSsh,
   getEncodedMessage,
   getDERfromPEM,
-  string2ArrayBuffer,
   base64encode,
+  string2Uint8Array,
 } from "./utils.js";
 
 import { subtle, convertPrivateKey } from "#crypto";
@@ -52,12 +52,12 @@ export async function getToken({ privateKey, payload }) {
   );
 
   const encodedMessage = getEncodedMessage(header, payload);
-  const encodedMessageArrBuf = string2ArrayBuffer(encodedMessage);
+  const encodedMessageTypedArray = string2Uint8Array(encodedMessage);
 
   const signatureArrBuf = await subtle.sign(
     algorithm.name,
     importedKey,
-    encodedMessageArrBuf
+    encodedMessageTypedArray
   );
 
   const encodedSignature = base64encode(signatureArrBuf);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,15 +18,15 @@ export function isOpenSsh(privateKey) {
 
 /**
  * @param {string} str
- * @returns {ArrayBuffer}
+ * @returns {Uint8Array}
  */
-export function string2ArrayBuffer(str) {
+export function string2Uint8Array(str) {
   const buf = new ArrayBuffer(str.length);
   const bufView = new Uint8Array(buf);
   for (let i = 0, strLen = str.length; i < strLen; i++) {
     bufView[i] = str.charCodeAt(i);
   }
-  return buf;
+  return bufView;
 }
 
 /**
@@ -41,7 +41,7 @@ export function getDERfromPEM(pem) {
     .join("");
 
   const decoded = atob(pemB64);
-  return string2ArrayBuffer(decoded);
+  return string2Uint8Array(decoded);
 }
 
 /**


### PR DESCRIPTION
In Next.js application, when running on an edge runtime environment, we encounter the following error:

`[TypeError: Failed to execute 'importKey' on 'SubtleCrypto': 2nd argument is not instance of ArrayBuffer, Buffer, TypedArray, or DataView.]`

It appears that using importKey with an ArrayBuffer leads to a compatibility issue in the edge runtime. However, returning a Uint8Array (a TypedArray) from string2ArrayBuffer resolves the problem and allows the code to work without error.
