### PR TITLE
Be more specific when exporting node:crypto

### DIFF
--- a/lib/crypto-node.js
+++ b/lib/crypto-node.js
@@ -1,5 +1,5 @@
 // this can be removed once we only support Node 20+
-export * from "node:crypto";
+export { subtle } from "node:crypto";
 import { createPrivateKey } from "node:crypto";
 
 import { isPkcs1 } from "./utils.js";


### PR DESCRIPTION
only exports the actually called function. Enables bun support.