### PR TITLE
Accept PKCS#1 private keys when using WebCrypto

### DIFF
--- a/lib/get-token.js
+++ b/lib/get-token.js
@@ -1,6 +1,7 @@
 // we don't @ts-check here because it chokes crypto which is a global API in modern JS runtime environments
 
 import {
+  convertPkcs1ToPkcs8,
   isPkcs1,
   isOpenSsh,
   getEncodedMessage,
@@ -17,13 +18,12 @@ import { subtle, convertPrivateKey } from "#crypto";
  */
 export async function getToken({ privateKey, payload }) {
   const convertedPrivateKey = convertPrivateKey(privateKey);
+  let privateKeyDER = getDERfromPEM(convertedPrivateKey);
 
-  // WebCrypto only supports PKCS#8, unfortunately
+  // WebCrypto only supports PKCS#8, so conversion from PKCS#1 may be necessary
   /* c8 ignore start */
   if (isPkcs1(convertedPrivateKey)) {
-    throw new Error(
-      "[universal-github-app-jwt] Private Key is in PKCS#1 format, but only PKCS#8 is supported. See https://github.com/gr2m/universal-github-app-jwt#private-key-formats"
-    );
+    privateKeyDER = convertPkcs1ToPkcs8(convertedPrivateKey);
   }
   /* c8 ignore stop */
 
@@ -42,7 +42,6 @@ export async function getToken({ privateKey, payload }) {
   /** @type {import('../internals.d.ts').Header} */
   const header = { alg: "RS256", typ: "JWT" };
 
-  const privateKeyDER = getDERfromPEM(convertedPrivateKey);
   const importedKey = await subtle.importKey(
     "pkcs8",
     privateKeyDER,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,7 @@ export function convertPkcs1ToPkcs8(privateKey) {
   const rsaKey = getDERfromPEM(privateKey);
   // PKCS#8 framing template
   const header = string2ArrayBuffer(atob('MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKg='));
-  // Concat the PKCS#8 key onto the framing
+  // Concat the PKCS#1 key onto the PKCS#8 framing
   const decodedKey = new Uint8Array(header.byteLength + rsaKey.byteLength);
   decodedKey.set(header, 0);
   decodedKey.set(rsaKey, header.byteLength);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,27 @@ export function isPkcs1(privateKey) {
 }
 
 /**
+ * Wrap PKCS#1 key with PKCS#8 ASN.1 structure, so WebCrypto can understand it
+ * @param {string} privateKey
+ * @returns {string}
+ */
+export function convertPkcs1ToPkcs8(privateKey) {
+  const rsaKey = getDERfromPEM(privateKey);
+  // PKCS#8 framing template
+  const header = string2ArrayBuffer(atob('MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKg='));
+  // Concat the PKCS#8 key onto the framing
+  const decodedKey = new Uint8Array(header.byteLength + rsaKey.byteLength);
+  decodedKey.set(header, 0);
+  decodedKey.set(rsaKey, header.byteLength);
+  // Update the message length fields inside the framing to match
+  const view = new DataView(decodedKey.buffer);
+  view.setUint16(2, decodedKey.byteLength - 4);
+  view.setUint16(24, rsaKey.byteLength);
+  // Return final Uint8Array
+  return decodedKey;
+}
+
+/**
  * @param {string} privateKey
  * @returns {boolean}
  */


### PR DESCRIPTION
Hi,
* Given that Github gives out `PKCS#1` PEM files while WebCrypto requires `PKCS#8` PEM data,
* and given that `PKCS#8` is used as a wrapper for `PKCS#1` keys,
* this PR adds a function that converts the Github-provided key for direct import into WebCrypto,
* using only Javascript primitives (`Uint8Array`, `DataView`, `atob`).

I use this function already in [a Deno-based library](https://github.com/cloudydeno/bitesized/blob/main/crypto/rsa-import.ts), and wanted to offer it back to this library so that Octokit could benefit from it. I have not tested its behavior with private keys from sources other than Github.

If there is an appetite to bring in this logic then I would appreciate understanding the next steps for this PR. For example I imagine that the `c8 ignore` would be dropped.